### PR TITLE
docs: update docs to use https instead of ssh for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,21 @@ tox
 pip install -e ../path/to/catalog-tools
 
 # if you don't need to do live changes in catalog-tools you can install it "from source"
-pip install git+ssh://git@github.com/swiss-seismological-service/catalog-tools.git
+pip install git+https://github.com/swiss-seismological-service/catalog-tools.git
 
 # if you want to install a specific branch:
-pip install git+ssh://git@github.com/swiss-seismological-service/catalog-tools.git@feature/branch
+pip install git+https://github.com/swiss-seismological-service/catalog-tools.git@feature/branch
 
 # update it once the repo has changed:
-pip install --force-reinstall git+ssh://git@github.com/swiss-seismological-service/catalog-tools.git
+pip install --force-reinstall git+https://github.com/swiss-seismological-service/catalog-tools.git
 ```
 
-### Problems with cartopy / geos
+### Problems with geos
 
 ```
 1. geos_c.h not found
 Solutions (Mac):
 brew install geos
-Solutions (Linux, not tested yet):
+Solutions:
 sudo apt-get libgeos-dev
-
-2. Cartopy failed to build wheel x86_64_linux-gnu-gcc
-Solution: use conda to install cartopy
-Linux/Ubuntu 64bit:
-conda install -c conda-forge cartopy
 ```


### PR DESCRIPTION
The thing is, that if you use ssh to interact with github/gitlab from the commandline, then you need to have your ssh key registered on github/lab. This is Git specific and not Repository specific.

Since many people have no idea how that works or what the problem is, I suggest updating this to use http instead of ssh.