### PR TITLE
Complete Definition of Catalogs

### DIFF
--- a/seismostats/io/client.py
+++ b/seismostats/io/client.py
@@ -90,5 +90,12 @@ class FDSNWSEventClient():
         r = requests.get(request_url, stream=True)
         catalog = parse_quakeml_response(r, includequality=includequality)
 
-        return Catalog.from_dict(
+        catalog = Catalog.from_dict(
             catalog, include_uncertainty, include_ids)
+
+        if start_time:
+            catalog.starttime = start_time
+        if end_time:
+            catalog.endtime = end_time
+
+        return catalog

--- a/seismostats/seismicity/catalog.py
+++ b/seismostats/seismicity/catalog.py
@@ -496,6 +496,8 @@ class ForecastCatalog(Catalog):
             Data to initialize the catalog with.
         name : str, optional
             Name of the catalog.
+        n_catalogs : int, optional
+            Total number of catalogs represented, including empty catalogs.
         *args, **kwargs : optional
             Additional arguments and keyword arguments to pass to pandas
             DataFrame constructor.
@@ -506,12 +508,12 @@ class ForecastCatalog(Catalog):
     """
 
     _required_cols = REQUIRED_COLS_CATALOG + ['catalog_id']
-    _metadata = Catalog._metadata + ['total_catalogs']
+    _metadata = Catalog._metadata + ['n_catalogs']
 
-    def __init__(self, data=None, *args, name=None, **kwargs):
+    def __init__(self, data=None, *args, n_catalogs=None, **kwargs):
         super().__init__(data, *args, **kwargs)
         # Total number of catalogs represented, inculding empty catalogs
-        self.total_catalogs = None
+        self.n_catalogs = n_catalogs
 
     @require_cols(require=_required_cols)
     def to_quakeml(self, agencyID=' ', author=' ') -> str:

--- a/seismostats/seismicity/catalog.py
+++ b/seismostats/seismicity/catalog.py
@@ -506,11 +506,12 @@ class ForecastCatalog(Catalog):
     """
 
     _required_cols = REQUIRED_COLS_CATALOG + ['catalog_id']
+    _metadata = Catalog._metadata + ['total_catalogs']
 
     def __init__(self, data=None, *args, name=None, **kwargs):
         super().__init__(data, *args, **kwargs)
-        # Represent catalogs with no events
-        self.empty_catalogs = None
+        # Total number of catalogs represented, inculding empty catalogs
+        self.total_catalogs = None
 
     @require_cols(require=_required_cols)
     def to_quakeml(self, agencyID=' ', author=' ') -> str:

--- a/seismostats/seismicity/catalog.py
+++ b/seismostats/seismicity/catalog.py
@@ -89,8 +89,7 @@ class Catalog(pd.DataFrame):
         **kwargs
     ):
         if data is None and 'columns' not in kwargs:
-            super().__init__(columns=REQUIRED_COLS_CATALOG, *args,
-                             starttime=None, endtime=None, **kwargs)
+            super().__init__(columns=REQUIRED_COLS_CATALOG, *args, **kwargs)
         else:
             super().__init__(data, *args, **kwargs)
 

--- a/seismostats/seismicity/catalog.py
+++ b/seismostats/seismicity/catalog.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+
 from seismostats.analysis.estimate_beta import estimate_b
 from seismostats.analysis.estimate_mc import mc_ks
 from seismostats.io.parser import parse_quakeml, parse_quakeml_file
@@ -71,7 +72,8 @@ class Catalog(pd.DataFrame):
         2          2         2      2 2021-01-01 00:00:00          3
     """
 
-    _metadata = ['name', '_required_cols', 'mc', 'delta_m', 'b_value']
+    _metadata = ['name', '_required_cols', 'mc',
+                 'delta_m', 'b_value', 'starttime', 'endtime']
     _required_cols = REQUIRED_COLS_CATALOG
 
     def __init__(
@@ -79,13 +81,16 @@ class Catalog(pd.DataFrame):
         data=None,
         *args,
         name=None,
+        starttime=None,
+        endtime=None,
         mc=None,
         delta_m=None,
         b_value=None,
         **kwargs
     ):
         if data is None and 'columns' not in kwargs:
-            super().__init__(columns=REQUIRED_COLS_CATALOG, *args, **kwargs)
+            super().__init__(columns=REQUIRED_COLS_CATALOG, *args,
+                             starttime=None, endtime=None, **kwargs)
         else:
             super().__init__(data, *args, **kwargs)
 
@@ -97,6 +102,12 @@ class Catalog(pd.DataFrame):
         self.mc = mc
         self.b_value = b_value
         self.delta_m = delta_m
+
+        self.starttime = starttime if isinstance(
+            starttime, pd.Timestamp) else pd.to_datetime(starttime)
+
+        self.endtime = endtime if isinstance(
+            endtime, pd.Timestamp) else pd.to_datetime(endtime)
 
     @classmethod
     def from_quakeml(cls, quakeml: str,
@@ -495,6 +506,11 @@ class ForecastCatalog(Catalog):
     """
 
     _required_cols = REQUIRED_COLS_CATALOG + ['catalog_id']
+
+    def __init__(self, data=None, *args, name=None, **kwargs):
+        super().__init__(data, *args, **kwargs)
+        # Represent catalogs with no events
+        self.empty_catalogs = None
 
     @require_cols(require=_required_cols)
     def to_quakeml(self, agencyID=' ', author=' ') -> str:


### PR DESCRIPTION
- To have all important information, a `Catalog` needs to include the information about the timeperiod for which it contains the events.
- A `ForecastCatalog` contains n realizations of a `Catalog`, identified by the `catalog_id` column. However we also need the information how many catalogs (n) in total there are, since it is possible that only m<n catalogs contain events and are represented in the `ForecastCatalog`.