### PR TITLE
Global configs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ extensions = [
 
 templates_path = ['_templates']
 exclude_patterns = []
-
+napoleon_custom_sections = [('Returns', 'params_style')]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/reference/config.md
+++ b/docs/source/reference/config.md
@@ -1,0 +1,16 @@
+# Settings and Options
+
+```{eval-rst}
+.. currentmodule:: seismostats
+```
+
+
+## Working with options
+    
+```{eval-rst}
+.. autosummary::
+    :toctree: api/
+
+    set_option
+    get_option
+```

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -4,4 +4,5 @@
 :maxdepth: 2
 
 catalog
+config
 ```

--- a/seismostats/__init__.py
+++ b/seismostats/__init__.py
@@ -17,6 +17,7 @@ from seismostats.plots.statistical import plot_mc_vs_b
 # seismicity
 from seismostats.seismicity.catalog import Catalog, ForecastCatalog
 from seismostats.seismicity.rategrid import ForecastGRRateGrid, GRRateGrid
+from seismostats.utils._config import get_option, set_option
 
 # utils
 from seismostats.utils.binning import bin_to_precision

--- a/seismostats/utils/_config.py
+++ b/seismostats/utils/_config.py
@@ -1,0 +1,46 @@
+from typing import Any, TypedDict
+
+Options = TypedDict('Options', {'warnings': bool})
+
+__options = Options(warnings=True)
+
+
+def set_option(key: str, value: Any):
+    """
+    Sets the value of the specified option.
+
+        Available options:
+            - 'warnings': bool (default: True)
+                If True, warnings will be shown.
+
+    Args:
+        key : str, The option to set.
+        value : Any, The value to set the option to.
+
+    Raises:
+        KeyError: If the key is not in the available options.
+
+    """
+    global __options
+    if key in __options:
+        __options[key] = value
+    else:
+        raise KeyError(f'Key "{key}" not in config.')
+
+
+def get_option(key: str):
+    """
+    Gets the value of the specified option.
+
+        Available options:
+            - 'warnings': bool (default: True)
+                If True, warnings will be shown.
+
+    Args:
+        key : str, The option to get.
+
+    Returns:
+        Any, The value of the option.
+    """
+
+    return __options[key]

--- a/seismostats/utils/tests/test_config.py
+++ b/seismostats/utils/tests/test_config.py
@@ -1,0 +1,16 @@
+import pytest
+
+from seismostats import get_option, set_option
+from seismostats.utils._config import __options
+
+
+def test_config():
+    warnings = get_option('warnings')
+    assert warnings is __options['warnings']
+
+    set_option('warnings', False)
+    warnings = get_option('warnings')
+    assert warnings is False
+
+    with pytest.raises(KeyError):
+        set_option('unknown', 'value')

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ doc =
     sphinx
     myst-parser
     sphinx-autobuild
+    pandoc
     pydata-sphinx-theme
     nbsphinx
     nbsphinx-link

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ python_requires = >=3.10
 packages = find:
 install_requires =
     cartopy
+    fiona
     geopandas
     jinja2
     requests
@@ -31,6 +32,7 @@ dev =
     tox
 
 doc = 
+    docutils==0.19
     sphinx
     myst-parser
     sphinx-autobuild


### PR DESCRIPTION
Add global options. Currently used to control display of warnings.

use `get_option('warnings')` to get the value of the `warnings` option, use `set_option('warnings', False)` to disable display of warnings.

(obviously, the actual display/hiding of the warnings still needs to be implemented)