### PR TITLE
adjusted new naming convention classic instead of tinti

### DIFF
--- a/seismostats/__init__.py
+++ b/seismostats/__init__.py
@@ -2,9 +2,10 @@
 
 # flake8: noqa
 
-from seismostats.analysis.estimate_a import estimate_a
 # analysis
 from seismostats.analysis.estimate_beta import estimate_b, shi_bolt_confidence
+from seismostats.analysis.estimate_a import estimate_a
+
 # seismicity
 from seismostats.catalogs.catalog import Catalog, ForecastCatalog
 from seismostats.catalogs.rategrid import ForecastGRRateGrid, GRRateGrid

--- a/seismostats/analysis/__init__.py
+++ b/seismostats/analysis/__init__.py
@@ -3,7 +3,7 @@
 from seismostats.analysis.estimate_beta import (estimate_b_kijko_smit,
                                                 estimate_b_laplace,
                                                 estimate_b_positive,
-                                                estimate_b_tinti,
+                                                estimate_b_classic,
                                                 estimate_b_utsu,
                                                 estimate_b_weichert,
                                                 estimate_b_kijko_smit,

--- a/seismostats/analysis/estimate_beta.py
+++ b/seismostats/analysis/estimate_beta.py
@@ -65,7 +65,7 @@ def estimate_b(
 
                 - 'classic',default, this is the is the classic estimator, see
                   :func:`seismostats.analysis.estimate_b_classic`
-                - 'positive' (this is b-positive, which applies the 'tinti'
+                - 'positive' (this is b-positive, which applies the 'classic'
                   method to the positive differences, see
                   :func:`seismostats.analysis.estimate_b_positive`. To
                   achieve the effect of reduced STAI, the magnitudes must

--- a/seismostats/analysis/estimate_beta.py
+++ b/seismostats/analysis/estimate_beta.py
@@ -41,7 +41,7 @@ def estimate_b(
     weights: list | None = None,
     b_parameter: str = "b_value",
     return_std: bool = False,
-    method="tinti",
+    method="classic",
     return_n: bool = False,
 ) -> float | tuple[float, float] | tuple[float, float, float]:
     """Return the maximum likelihood estimator for the Gutenberg-Richter
@@ -63,8 +63,8 @@ def estimate_b(
         method:     method to use for estimation of beta/b-value. Options
                 are:
 
-                - 'tinti',default, this is the is the classic estimator, see
-                  :func:`seismostats.analysis.estimate_b_tinti`
+                - 'classic',default, this is the is the classic estimator, see
+                  :func:`seismostats.analysis.estimate_b_classic`
                 - 'positive' (this is b-positive, which applies the 'tinti'
                   method to the positive differences, see
                   :func:`seismostats.analysis.estimate_b_positive`. To
@@ -98,8 +98,8 @@ def estimate_b(
                 "check if mc is chosen correctly"
             )
 
-    if method == "tinti":
-        return estimate_b_tinti(
+    if method == "classic":
+        return estimate_b_classic(
             magnitudes,
             mc=mc,
             delta_m=delta_m,
@@ -118,10 +118,10 @@ def estimate_b(
         )
 
     else:
-        raise ValueError("method must be either 'tinti' or 'positive'")
+        raise ValueError("method must be either 'classic' or 'positive'")
 
 
-def estimate_b_tinti(
+def estimate_b_classic(
     magnitudes: np.ndarray,
     mc: float,
     delta_m: float = 0,
@@ -301,7 +301,7 @@ def estimate_b_positive(
     # previous one. delta_m is added to avoid numerical errors
     mag_diffs = abs(mag_diffs[mag_diffs > dmc - delta_m / 2])
 
-    out = estimate_b_tinti(
+    out = estimate_b_classic(
         mag_diffs,
         mc=dmc,
         delta_m=delta_m,
@@ -375,7 +375,7 @@ def estimate_b_more_positive(
     # only take the values where the next earthquake is larger
     mag_diffs = abs(mag_diffs[mag_diffs > - delta_m / 2])
 
-    out = estimate_b_tinti(
+    out = estimate_b_classic(
         mag_diffs,
         mc=dmc,
         delta_m=delta_m,
@@ -484,7 +484,7 @@ def estimate_b_laplace(
     mag_diffs = abs(mag_diffs)
     mag_diffs = mag_diffs[mag_diffs > 0]
 
-    out = estimate_b_tinti(
+    out = estimate_b_classic(
         mag_diffs,
         mc=delta_m,
         delta_m=delta_m,

--- a/seismostats/analysis/estimate_mc.py
+++ b/seismostats/analysis/estimate_mc.py
@@ -281,7 +281,7 @@ def mc_ks(
             warnings.warn("Both beta and b_method are given. Using beta.")
 
     if beta is None and b_method is None:
-        b_method = "tinti"
+        b_method = "classic"
 
     mcs_tested = []
     ks_ds = []

--- a/seismostats/analysis/tests/test_estimate_beta.py
+++ b/seismostats/analysis/tests/test_estimate_beta.py
@@ -11,7 +11,7 @@ from seismostats.analysis.estimate_beta import (
     estimate_b,
     estimate_b_laplace,
     estimate_b_positive,
-    estimate_b_tinti,
+    estimate_b_classic,
     estimate_b_utsu,
     estimate_b_weichert,
     shi_bolt_confidence,
@@ -24,8 +24,8 @@ from seismostats.utils.simulate_distributions import simulate_magnitudes_binned
 @pytest.mark.parametrize(
     "method, return_std, return_n, b_parameter",
     [
-        ("tinti", True, True, "beta"),
-        ("tinti", False, False, "b_value"),
+        ("classic", True, True, "beta"),
+        ("classic", False, False, "b_value"),
         ("positive", True, True, "beta"),
         ("positive", False, False, "b_value"),
         ("positive", True, False, "beta"),
@@ -112,7 +112,7 @@ def test_estimate_b_tinti(
     mags = simulate_magnitudes_binned(
         n, b, mc, delta_m, b_parameter=b_parameter
     )
-    b_estimate = estimate_b_tinti(mags, mc, delta_m, b_parameter=b_parameter)
+    b_estimate = estimate_b_classic(mags, mc, delta_m, b_parameter=b_parameter)
 
     assert abs(b - b_estimate) / b <= precision
 

--- a/seismostats/analysis/tests/test_estimate_beta.py
+++ b/seismostats/analysis/tests/test_estimate_beta.py
@@ -101,7 +101,7 @@ def test_estimate_b(
         (1000000, np.log(10), 3, 0.1, "beta", 0.01),
     ],
 )
-def test_estimate_b_tinti(
+def test_estimate_b_classic(
     n: int,
     b: float,
     mc: float,

--- a/seismostats/plots/statistical.py
+++ b/seismostats/plots/statistical.py
@@ -8,7 +8,7 @@ from scipy.stats import norm
 # Own functions
 from seismostats.analysis.estimate_beta import (
     estimate_b_positive,
-    estimate_b_tinti,
+    estimate_b_classic,
 )
 
 
@@ -16,7 +16,7 @@ def plot_mc_vs_b(
     magnitudes: np.ndarray,
     mcs: np.ndarray,
     delta_m: float = 0.1,
-    method: str = "tinti",
+    method: str = "classic",
     confidence_intvl: float = 0.95,
     ax: plt.Axes | None = None,
     color: str = "blue",
@@ -27,7 +27,7 @@ def plot_mc_vs_b(
         magnitudes: magnitudes of the catalog
         mcs:        completeness magnitudes (list or numpy array)
         delta_m:    discretization of the magnitudes
-        method:     method used for b-value estimation, either 'tinti' or
+        method:     method used for b-value estimation, either 'classic' or
                     'positive' or 'positive_postcut'. positive_postcut is the
                     same as 'positive' but with the postcut method (differences
                     are taken before cutting the magnitudes below the
@@ -43,9 +43,9 @@ def plot_mc_vs_b(
 
     # try except
     try:
-        if method == "tinti":
+        if method == "classic":
             results = [
-                estimate_b_tinti(
+                estimate_b_classic(
                     magnitudes[magnitudes >= mc],
                     mc,
                     delta_m=delta_m,
@@ -66,7 +66,7 @@ def plot_mc_vs_b(
             mag_diffs = np.diff(magnitudes)
             mag_diffs = mag_diffs[mag_diffs > 0]
             results = [
-                estimate_b_tinti(
+                estimate_b_classic(
                     mag_diffs[mag_diffs >= mc],
                     mc=mc,
                     delta_m=delta_m,


### PR DESCRIPTION
before, the b-value estimation function accepted either “positive” or "tinti". Now, to make it compatible with the a-value functions, we call it "classic" intead of "tinti". The refenrence to the tinti paper is still included.