### PR TITLE
Feature/weights

### DIFF
--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -7,8 +7,8 @@ from typing_extensions import Self
 
 from seismostats.analysis.bvalue.utils import (b_value_to_beta,
                                                shi_bolt_confidence)
-from seismostats.utils.binning import binning_test
 from seismostats.utils._config import get_option
+from seismostats.utils.binning import binning_test
 
 
 class BValueEstimator(ABC):
@@ -92,6 +92,11 @@ class BValueEstimator(ABC):
             binning_test(self.magnitudes, self.delta_m, tolerance)
         )
         "Magnitudes are not binned correctly."
+
+        if self.weights is not None:
+            assert len(self.magnitudes) == len(self.weights), (
+                "The number of magnitudes and weights must be equal."
+            )
 
         # test if lowest magnitude is much larger than mc
         if get_option("warnings") is True:

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -70,7 +70,15 @@ class BValueEstimator(ABC):
         Shi and Bolt estimate of the beta/b-value estimate.
         '''
         assert self.__b_value is not None, 'Please run the estimator first.'
+        if get_option('warnings') is True:
+            if self.weights is not None:
+                warnings.warn(
+                    'Shi and Bolt confidence with weights considers the magnitudes as '
+                    'having length {}, the sum of relevant weights.'.format(
+                        np.sum(self.weights))
+                )
         return shi_bolt_confidence(self.magnitudes,
+                                   weights=self.weights,
                                    b=self.__b_value,
                                    b_parameter=self.__b_parameter)
 
@@ -97,6 +105,7 @@ class BValueEstimator(ABC):
             assert len(self.magnitudes) == len(self.weights), (
                 "The number of magnitudes and weights must be equal."
             )
+            assert np.all(self.weights >= 0), "Weights must be nonnegative."
 
         # test if lowest magnitude is much larger than mc
         if get_option("warnings") is True:

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -73,7 +73,8 @@ class BValueEstimator(ABC):
         if get_option('warnings') is True:
             if self.weights is not None:
                 warnings.warn(
-                    'Shi and Bolt confidence with weights considers the magnitudes as '
+                    'Shi and Bolt confidence with weights considers the '
+                    'magnitudes as '
                     'having length {}, the sum of relevant weights.'.format(
                         np.sum(self.weights))
                 )

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -38,6 +38,8 @@ class BPositiveBValueEstimator(BValueEstimator):
         # only take the values where the next earthquake is d_mc larger than the
         # previous one. delta_m is added to avoid numerical errors
         if self.weights is not None:
+            # use weight of second earthquake of a difference
+            self.weights = self.weights[1:]
             self.weights = self.weights[self.magnitudes
                                         > self.dmc - self.delta_m / 2]
         self.magnitudes = abs(

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -21,7 +21,7 @@ class BPositiveBValueEstimator(BValueEstimator):
                 value are not considered). If None, the cutoff is set to delta_m
     '''
 
-    weights_supported = False
+    weights_supported = True
 
     def __init__(self, dmc: float | None = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -37,10 +37,13 @@ class BPositiveBValueEstimator(BValueEstimator):
         self.magnitudes = np.diff(self.magnitudes)
         # only take the values where the next earthquake is d_mc larger than the
         # previous one. delta_m is added to avoid numerical errors
+        if self.weights is not None:
+            self.weights = self.weights[self.magnitudes
+                                        > self.dmc - self.delta_m / 2]
         self.magnitudes = abs(
             self.magnitudes[self.magnitudes > self.dmc - self.delta_m / 2])
 
         classic_estimator = ClassicBValueEstimator(mc=self.dmc,
                                                    delta_m=self.delta_m)
 
-        return classic_estimator(self.magnitudes)
+        return classic_estimator(self.magnitudes, self.weights)

--- a/seismostats/analysis/bvalue/tests/test_bvalues.py
+++ b/seismostats/analysis/bvalue/tests/test_bvalues.py
@@ -45,8 +45,10 @@ def test_estimate_b_classic(
     mags = mags[mags >= mc - delta_m / 2]
     estimator = ClassicBValueEstimator(mc=mc, delta_m=delta_m)
     b_estimate = estimator(mags)
+    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
 
     assert_almost_equal(b_estimate, b_est_correct)
+    assert_almost_equal(b_estimate, b_estimate_weighted)
 
 
 @pytest.mark.parametrize(
@@ -67,7 +69,10 @@ def test_estimate_b_utsu(
     mags = mags[mags >= mc - delta_m / 2]
     estimator = UtsuBValueEstimator(mc=mc, delta_m=delta_m)
     b_estimate = estimator(mags)
+    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
+
     assert_almost_equal(b_estimate, b_est_correct)
+    assert_almost_equal(b_estimate, b_estimate_weighted)
 
 
 @pytest.mark.parametrize(
@@ -89,7 +94,10 @@ def test_estimate_b_positive(
     mags = mags[mags >= mc - delta_m / 2]
     estimator = BPositiveBValueEstimator(mc=mc, delta_m=delta_m, dmc=dmc)
     b_estimate = estimator(mags)
+    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
+
     assert_almost_equal(b_estimate, b_est_correct)
+    assert_almost_equal(b_estimate, b_estimate_weighted)
 
 
 @pytest.mark.parametrize(
@@ -111,4 +119,7 @@ def test_estimate_b_more_positive(
     mags = mags[mags >= mc - delta_m / 2]
     estimator = BMorePositiveBValueEstimator(mc=mc, delta_m=delta_m, dmc=dmc)
     b_estimate = estimator(mags)
+    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
+
     assert_almost_equal(b_estimate, b_est_correct)
+    assert_almost_equal(b_estimate, b_estimate_weighted)

--- a/seismostats/analysis/bvalue/tests/test_bvalues.py
+++ b/seismostats/analysis/bvalue/tests/test_bvalues.py
@@ -43,14 +43,20 @@ def test_estimate_b_classic(
 ):
     mags = bin_to_precision(mags, delta_m)
     mags = mags[mags >= mc - delta_m / 2]
+    mags_extended = np.concatenate([mags, mags + 0.1])
+    weights = np.ones(len(mags))
+    weights_extended = np.concatenate([weights, 0 * weights])
+
     estimator = ClassicBValueEstimator(mc=mc, delta_m=delta_m)
     b_estimate = estimator(mags)
-    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
-    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
+    b_estimate_weighted = estimator(mags, weights=weights)
+    b_estimate_half_weighted = estimator(mags, weights=weights * 0.5)
+    b_estimate_extended = estimator(mags_extended, weights=weights_extended)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
     assert_almost_equal(b_estimate, b_estimate_half_weighted)
+    assert_almost_equal(b_estimate, b_estimate_extended)
 
 
 @pytest.mark.parametrize(
@@ -69,14 +75,20 @@ def test_estimate_b_utsu(
 ):
     mags = bin_to_precision(mags, delta_m)
     mags = mags[mags >= mc - delta_m / 2]
+    mags_extended = np.concatenate([mags, mags + 0.1])
+    weights = np.ones(len(mags))
+    weights_extended = np.concatenate([weights, 0 * weights])
+
     estimator = UtsuBValueEstimator(mc=mc, delta_m=delta_m)
     b_estimate = estimator(mags)
-    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
-    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
+    b_estimate_weighted = estimator(mags, weights=weights)
+    b_estimate_half_weighted = estimator(mags, weights=weights * 0.5)
+    b_estimate_extended = estimator(mags_extended, weights=weights_extended)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
     assert_almost_equal(b_estimate, b_estimate_half_weighted)
+    assert_almost_equal(b_estimate, b_estimate_extended)
 
 
 @pytest.mark.parametrize(
@@ -96,14 +108,20 @@ def test_estimate_b_positive(
 ):
     mags = bin_to_precision(mags, delta_m)
     mags = mags[mags >= mc - delta_m / 2]
+    mags_extended = np.concatenate([mags, mags + 0.1])
+    weights = np.ones(len(mags))
+    weights_extended = np.concatenate([weights, 0 * weights])
+
     estimator = BPositiveBValueEstimator(mc=mc, delta_m=delta_m, dmc=dmc)
     b_estimate = estimator(mags)
-    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
-    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
+    b_estimate_weighted = estimator(mags, weights=weights)
+    b_estimate_half_weighted = estimator(mags, weights=weights * 0.5)
+    b_estimate_extended = estimator(mags_extended, weights=weights_extended)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
     assert_almost_equal(b_estimate, b_estimate_half_weighted)
+    assert_almost_equal(b_estimate, b_estimate_extended)
 
 
 @pytest.mark.parametrize(
@@ -123,10 +141,12 @@ def test_estimate_b_more_positive(
 ):
     mags = bin_to_precision(mags, delta_m)
     mags = mags[mags >= mc - delta_m / 2]
+    weights = np.ones(len(mags))
+
     estimator = BMorePositiveBValueEstimator(mc=mc, delta_m=delta_m, dmc=dmc)
     b_estimate = estimator(mags)
-    b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
-    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
+    b_estimate_weighted = estimator(mags, weights=weights)
+    b_estimate_half_weighted = estimator(mags, weights=weights * 0.5)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)

--- a/seismostats/analysis/bvalue/tests/test_bvalues.py
+++ b/seismostats/analysis/bvalue/tests/test_bvalues.py
@@ -62,7 +62,7 @@ def test_estimate_b_classic(
 @pytest.mark.parametrize(
     "b_est_correct, mags, mc, delta_m",
     [
-        (0.9941299341459253, magnitudes(1), 0, delta_m),
+        (0.9941299341459253, magnitudes(1), 0, 0.1),
         (1.485969980462011, magnitudes(1.5), 0.5, 0.01),
         (0.49903218920704306, magnitudes(0.5), 2, 0.2),
     ],

--- a/seismostats/analysis/bvalue/tests/test_bvalues.py
+++ b/seismostats/analysis/bvalue/tests/test_bvalues.py
@@ -43,7 +43,7 @@ def test_estimate_b_classic(
 ):
     mags = bin_to_precision(mags, delta_m)
     mags = mags[mags >= mc - delta_m / 2]
-    mags_extended = np.concatenate([mags, mags + 0.1])
+    mags_extended = np.concatenate([mags, mags + delta_m])
     weights = np.ones(len(mags))
     weights_extended = np.concatenate([weights, 0 * weights])
 
@@ -62,7 +62,7 @@ def test_estimate_b_classic(
 @pytest.mark.parametrize(
     "b_est_correct, mags, mc, delta_m",
     [
-        (0.9941299341459253, magnitudes(1), 0, 0.1),
+        (0.9941299341459253, magnitudes(1), 0, delta_m),
         (1.485969980462011, magnitudes(1.5), 0.5, 0.01),
         (0.49903218920704306, magnitudes(0.5), 2, 0.2),
     ],
@@ -75,7 +75,7 @@ def test_estimate_b_utsu(
 ):
     mags = bin_to_precision(mags, delta_m)
     mags = mags[mags >= mc - delta_m / 2]
-    mags_extended = np.concatenate([mags, mags + 0.1])
+    mags_extended = np.concatenate([mags, mags + delta_m])
     weights = np.ones(len(mags))
     weights_extended = np.concatenate([weights, 0 * weights])
 
@@ -108,7 +108,7 @@ def test_estimate_b_positive(
 ):
     mags = bin_to_precision(mags, delta_m)
     mags = mags[mags >= mc - delta_m / 2]
-    mags_extended = np.concatenate([mags, mags + 0.1])
+    mags_extended = np.concatenate([mags, mags + delta_m])
     weights = np.ones(len(mags))
     weights_extended = np.concatenate([weights, 0 * weights])
 

--- a/seismostats/analysis/bvalue/tests/test_bvalues.py
+++ b/seismostats/analysis/bvalue/tests/test_bvalues.py
@@ -46,9 +46,11 @@ def test_estimate_b_classic(
     estimator = ClassicBValueEstimator(mc=mc, delta_m=delta_m)
     b_estimate = estimator(mags)
     b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
+    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
+    assert_almost_equal(b_estimate, b_estimate_half_weighted)
 
 
 @pytest.mark.parametrize(
@@ -70,9 +72,11 @@ def test_estimate_b_utsu(
     estimator = UtsuBValueEstimator(mc=mc, delta_m=delta_m)
     b_estimate = estimator(mags)
     b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
+    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
+    assert_almost_equal(b_estimate, b_estimate_half_weighted)
 
 
 @pytest.mark.parametrize(
@@ -95,9 +99,11 @@ def test_estimate_b_positive(
     estimator = BPositiveBValueEstimator(mc=mc, delta_m=delta_m, dmc=dmc)
     b_estimate = estimator(mags)
     b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
+    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
+    assert_almost_equal(b_estimate, b_estimate_half_weighted)
 
 
 @pytest.mark.parametrize(
@@ -120,6 +126,8 @@ def test_estimate_b_more_positive(
     estimator = BMorePositiveBValueEstimator(mc=mc, delta_m=delta_m, dmc=dmc)
     b_estimate = estimator(mags)
     b_estimate_weighted = estimator(mags, weights=np.ones(len(mags)))
+    b_estimate_half_weighted = estimator(mags, weights=np.ones(len(mags)) * 0.5)
 
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
+    assert_almost_equal(b_estimate, b_estimate_half_weighted)

--- a/seismostats/analysis/bvalue/tests/test_utils.py
+++ b/seismostats/analysis/bvalue/tests/test_utils.py
@@ -1,8 +1,8 @@
-from numpy.testing import assert_almost_equal
 from datetime import datetime
 
 import numpy as np
 import pytest
+from numpy.testing import assert_almost_equal
 
 from seismostats.analysis.bvalue.tests.test_bvalues import magnitudes
 from seismostats.analysis.bvalue.utils import (b_value_to_beta,
@@ -55,5 +55,14 @@ def test_make_more_incomplete():
 )
 def test_shi_bolt_confidence(
         std: float, mags: np.ndarray, b: float, b_parameter: str):
-    assert_almost_equal(
-        shi_bolt_confidence(mags, b=b, b_parameter=b_parameter), std)
+    weights = np.ones(len(mags))
+
+    conf = shi_bolt_confidence(mags, b=b, b_parameter=b_parameter)
+    conf_weighted = shi_bolt_confidence(mags, weights=weights, b=b,
+                                        b_parameter=b_parameter)
+    conf_half_weighted = shi_bolt_confidence(
+        mags, weights=weights * 0.5, b=b, b_parameter=b_parameter)
+
+    assert_almost_equal(conf_weighted, std)
+    assert_almost_equal(conf, std)
+    assert (conf_half_weighted > conf)

--- a/seismostats/analysis/bvalue/utils.py
+++ b/seismostats/analysis/bvalue/utils.py
@@ -27,6 +27,7 @@ def b_value_to_beta(b_value: float) -> float:
 
 def shi_bolt_confidence(
     magnitudes: np.ndarray,
+    weights: np.ndarray | None = None,
     b: float | None = None,
     b_parameter: str = "b_value",
 ) -> float:
@@ -38,6 +39,7 @@ def shi_bolt_confidence(
 
     Args:
         magnitudes: numpy array of magnitudes
+        weights:    numpy array of weights for each magnitude
         b:          known or estimated b-value/beta of the magnitudes
         b_parameter:either either 'b_value' or 'beta'
 
@@ -50,8 +52,15 @@ def shi_bolt_confidence(
         b_parameter == "b_value" or b_parameter == "beta"
     ), "please choose either 'b_value' or 'beta' as b_parameter"
 
+    std_mags = np.sqrt(np.average(np.square(
+        magnitudes - np.average(magnitudes, weights=weights)), weights=weights))
+    if weights is None:
+        len_mags = len(magnitudes)
+    else:
+        len_mags = np.sum(weights)
+
     std_b = (
-        np.log(10) * b**2 * np.std(magnitudes) / np.sqrt(len(magnitudes) - 1)
+        np.log(10) * b**2 * std_mags / np.sqrt(len_mags - 1)
     )
     if b_parameter == "beta":
         std_b = (std_b) / np.log(10)

--- a/seismostats/analysis/bvalue/utsu.py
+++ b/seismostats/analysis/bvalue/utsu.py
@@ -6,7 +6,7 @@ from seismostats.analysis.bvalue.utils import beta_to_b_value
 
 class UtsuBValueEstimator(BValueEstimator):
 
-    weights_supported = False
+    weights_supported = True
 
     def __init__(self, *args, **kwargs):
         """Return the maximum likelihood b-value or beta.
@@ -24,5 +24,6 @@ class UtsuBValueEstimator(BValueEstimator):
         super().__init__(*args, **kwargs)
 
     def _estimate(self):
-        beta = 1 / np.mean(self.magnitudes - self.mc + self.delta_m / 2)
+        beta = 1 / np.average(self.magnitudes - self.mc
+                              + self.delta_m / 2, weights=self.weights)
         return beta_to_b_value(beta)


### PR DESCRIPTION
weights are now supported for classic, positive, more_positive, and utsu.
Weights are also implemented in the uncertainty calculation. here, each magnitude is treated as if it is x earthquakes, x being the weight. So, multiplying the weight vector by a factor will decrease the uncertainty (we can discuss if this is desired).

Tests so far only test that the result is the same if all weights are one, but we should include some actual weights tests.