### PR TITLE
fix: add dependency typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Library for statistical analysis of seismicity."
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 
-dependencies = ["cartopy", "fiona", "geopandas", "jinja2", "requests", "scipy"]
+dependencies = ["cartopy", "fiona", "geopandas", "jinja2", "requests", "scipy", "typing_extensions"]
 
 [project.optional-dependencies]
 dev = ["flake8", "isort", "pytest", "pytest-cov", "responses", "tox"]


### PR DESCRIPTION
Clients importing seismostats get the error `ModuleNotFoundError: No module named 'typing_extensions'`