### PR TITLE
Fix/classes

### DIFF
--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -18,6 +18,7 @@ class AValueEstimator(ABC):
         self.scaling_factor: float | None = None
         self.m_ref: float | None = None
         self.b_value: float | None = None
+        self.idx: np.ndarray | None = None
 
         self.__a_value: float | None = None
 

--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -59,8 +59,8 @@ class AValueEstimator(ABC):
         self.m_ref = m_ref
         self.b_value = b_value
 
-        self._sanity_checks()
         self._filtering()
+        self._sanity_checks()
 
         self.__a_value = self._estimate(*args, **kwargs)
         self.__a_value = self._reference_scaling(self.__a_value)

--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -18,7 +18,6 @@ class AValueEstimator(ABC):
         self.scaling_factor: float | None = None
         self.m_ref: float | None = None
         self.b_value: float | None = None
-        self.idx: np.ndarray | None = None
 
         self.__a_value: float | None = None
 
@@ -26,11 +25,9 @@ class AValueEstimator(ABC):
                   magnitudes: np.ndarray,
                   mc: float,
                   delta_m: float,
-                  *args,
                   scaling_factor: float | None = None,
                   m_ref: float | None = None,
-                  b_value: float | None = None,
-                  **kwargs) -> float:
+                  b_value: float | None = None) -> float:
         '''
         Return the a-value estimate.
 
@@ -59,27 +56,29 @@ class AValueEstimator(ABC):
         self.m_ref = m_ref
         self.b_value = b_value
 
-        self._filtering()
+        self._filter_magnitudes()
         self._sanity_checks()
 
-        self.__a_value = self._estimate(*args, **kwargs)
+        self.__a_value = self._estimate()
         self.__a_value = self._reference_scaling(self.__a_value)
 
         return self.__a_value
 
     @abstractmethod
-    def _estimate(self, *args, **kwargs) -> float:
+    def _estimate(self) -> float:
         '''
         Specific implementation of the a-value estimator.
         '''
         pass
 
-    def _filtering(self) -> np.ndarray:
+    def _filter_magnitudes(self) -> np.ndarray:
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        self.idx = self.magnitudes >= self.mc - self.delta_m / 2
-        self.magnitudes = self.magnitudes[self.idx]
+        idx = self.magnitudes >= self.mc - self.delta_m / 2
+        self.magnitudes = self.magnitudes[idx]
+
+        return idx
 
     def _sanity_checks(self):
         '''

--- a/seismostats/analysis/avalue/tests/test_avalue.py
+++ b/seismostats/analysis/avalue/tests/test_avalue.py
@@ -112,3 +112,12 @@ def test_estimate_a_more_positive():
     with pytest.raises(ValueError):
         estimate_a(mags, mc=0, delta_m=0.1, times=times,
                    m_ref=-1, method=AMorePositiveAValueEstimator)
+
+    # check that cutting at mc is handled correctly
+    mags = np.array([-0.5, 0.9, 0.9, 0.9, 0.9, 10.9])
+    times = np.arange(datetime(2000, 1, 1), datetime(
+        2000, 1, 7), timedelta(days=1)).astype(datetime)
+
+    a = estimator.calculate(
+        mags, 0, 0.1, times, b_value=1, dmc=0.1)
+    assert_almost_equal(10**a, 16.0)

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -17,6 +17,7 @@ class BValueEstimator(ABC):
         self.mc: float | None = None
         self.delta_m: float | None = None
         self.weights: np.ndarray | None = None
+        self.idx: np.ndarray | None = None
 
         self.__b_value: float | None = None
 

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -25,9 +25,7 @@ class BValueEstimator(ABC):
                   magnitudes: np.ndarray | list,
                   mc: float,
                   delta_m: float,
-                  *args,
-                  weights: np.ndarray | list | None = None,
-                  **kwargs) -> float:
+                  weights: np.ndarray | list | None = None) -> float:
         '''
         Return the b-value estimate.
 
@@ -46,28 +44,30 @@ class BValueEstimator(ABC):
         self.delta_m = delta_m
         self.weights = None if weights is None else np.array(weights)
 
-        self._filtering()
+        self._filter_magnitudes()
         self._sanity_checks()
 
-        self.__b_value = self._estimate(*args, **kwargs)
+        self.__b_value = self._estimate()
         return self.__b_value
 
     @abstractmethod
-    def _estimate(self, *args, **kwargs) -> float:
+    def _estimate(self) -> float:
         '''
         Specific implementation of the b-value estimator.
         '''
         pass
 
-    def _filtering(self):
+    def _filter_magnitudes(self):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        self.idx = self.magnitudes >= self.mc - self.delta_m / 2
-        self.magnitudes = self.magnitudes[self.idx]
+        idx = self.magnitudes >= self.mc - self.delta_m / 2
+        self.magnitudes = self.magnitudes[idx]
 
         if self.weights is not None:
-            self.weights = self.weights[self.idx]
+            self.weights = self.weights[idx]
+
+        return idx
 
     def _sanity_checks(self):
         '''

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -46,8 +46,8 @@ class BValueEstimator(ABC):
         self.delta_m = delta_m
         self.weights = None if weights is None else np.array(weights)
 
-        self._sanity_checks()
         self._filtering()
+        self._sanity_checks()
 
         self.__b_value = self._estimate(*args, **kwargs)
         return self.__b_value

--- a/seismostats/analysis/bvalue/classic.py
+++ b/seismostats/analysis/bvalue/classic.py
@@ -4,6 +4,23 @@ from seismostats.analysis.bvalue.base import BValueEstimator
 from seismostats.analysis.bvalue.utils import beta_to_b_value
 
 
+def _mle_estimator(magnitudes: np.ndarray,
+                   mc: float,
+                   delta_m: float,
+                   weights: np.ndarray | None = None) -> float:
+    '''
+    Internal function for the classic b-value estimator. For b-value
+    estimation use `ClassicBValueEstimator` instead.
+    '''
+    if delta_m > 0:
+        p = 1 + delta_m / np.average(magnitudes - mc, weights=weights)
+        beta = 1 / delta_m * np.log(p)
+    else:
+        beta = 1 / np.average(magnitudes - mc, weights=weights)
+
+    return beta_to_b_value(beta)
+
+
 class ClassicBValueEstimator(BValueEstimator):
     '''
     Estimator for the b-value using the maximum likelihood estimator.
@@ -20,13 +37,7 @@ class ClassicBValueEstimator(BValueEstimator):
         super().__init__()
 
     def _estimate(self) -> float:
-
-        if self.delta_m > 0:
-            p = 1 + self.delta_m / \
-                np.average(self.magnitudes - self.mc, weights=self.weights)
-            beta = 1 / self.delta_m * np.log(p)
-        else:
-            beta = 1 / np.average(self.magnitudes
-                                  - self.mc, weights=self.weights)
-
-        return beta_to_b_value(beta)
+        return _mle_estimator(self.magnitudes,
+                              mc=self.mc,
+                              delta_m=self.delta_m,
+                              weights=self.weights)

--- a/seismostats/analysis/bvalue/more_positive.py
+++ b/seismostats/analysis/bvalue/more_positive.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from seismostats.analysis.bvalue.base import BValueEstimator
-from seismostats.analysis.bvalue.classic import ClassicBValueEstimator
+from seismostats.analysis.bvalue.classic import _mle_estimator
 from seismostats.analysis.bvalue.utils import find_next_larger
 from seismostats.utils._config import get_option
 
@@ -73,9 +73,7 @@ class BMorePositiveBValueEstimator(BValueEstimator):
             weights = self.weights[idx_next_larger]
             self.weights = weights[~idx_no_next]
 
-        classic_estimator = ClassicBValueEstimator()
-
-        return classic_estimator.calculate(self.magnitudes,
-                                           mc=self.dmc,
-                                           delta_m=self.delta_m,
-                                           weights=self.weights)
+        return _mle_estimator(self.magnitudes,
+                              mc=self.mc,
+                              delta_m=self.delta_m,
+                              weights=self.weights)

--- a/seismostats/analysis/bvalue/more_positive.py
+++ b/seismostats/analysis/bvalue/more_positive.py
@@ -44,22 +44,20 @@ class BMorePositiveBValueEstimator(BValueEstimator):
                         below this value are not considered). If None,
                         the cutoff is set to delta_m.
         '''
+        self.dmc: float = dmc if dmc is not None else delta_m
+
+        if self.dmc < 0:
+            raise ValueError('dmc must be larger or equal to 0')
+
+        if self.dmc < delta_m and get_option('warnings') is True:
+            warnings.warn('dmc is smaller than delta_m, not recommended')
 
         return super().calculate(magnitudes,
                                  mc=mc,
                                  delta_m=delta_m,
-                                 weights=weights,
-                                 dmc=dmc)
+                                 weights=weights)
 
-    def _estimate(self, dmc: float) -> float:
-
-        self.dmc = dmc or self.delta_m
-
-        if self.dmc < 0:
-            raise ValueError('dmc must be larger or equal to 0')
-        elif self.dmc < self.delta_m and get_option('warnings') is True:
-            warnings.warn('dmc is smaller than delta_m, not recommended')
-
+    def _estimate(self) -> float:
         mag_diffs = -np.ones(len(self.magnitudes) - 1) * self.delta_m
 
         idx_next_larger = find_next_larger(
@@ -74,6 +72,6 @@ class BMorePositiveBValueEstimator(BValueEstimator):
             self.weights = weights[~idx_no_next]
 
         return _mle_estimator(self.magnitudes,
-                              mc=self.mc,
+                              mc=self.dmc,
                               delta_m=self.delta_m,
                               weights=self.weights)

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -42,21 +42,20 @@ class BPositiveBValueEstimator(BValueEstimator):
                         the cutoff is set to delta_m.
         '''
 
-        return super().calculate(magnitudes,
-                                 mc=mc,
-                                 delta_m=delta_m,
-                                 weights=weights,
-                                 dmc=dmc)
-
-    def _estimate(self, dmc: float | None = None) -> float:
-
-        self.dmc = dmc or self.delta_m
+        self.dmc: float = dmc if dmc is not None else delta_m
 
         if self.dmc < 0:
             raise ValueError('dmc must be larger or equal to 0')
 
-        elif self.dmc < self.delta_m and get_option('warnings') is True:
+        if self.dmc < delta_m and get_option('warnings') is True:
             warnings.warn('dmc is smaller than delta_m, not recommended')
+
+        return super().calculate(magnitudes,
+                                 mc=mc,
+                                 delta_m=delta_m,
+                                 weights=weights)
+
+    def _estimate(self, dmc: float | None = None) -> float:
 
         # only take the values where the next earthquake is d_mc larger than the
         # previous one. delta_m is added to avoid numerical errors

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from seismostats.analysis.bvalue.base import BValueEstimator
-from seismostats.analysis.bvalue.classic import ClassicBValueEstimator
+from seismostats.analysis.bvalue.classic import _mle_estimator
 from seismostats.utils._config import get_option
 
 
@@ -68,9 +68,7 @@ class BPositiveBValueEstimator(BValueEstimator):
             # use weight of second earthquake of a difference
             self.weights = self.weights[1:][is_larger]
 
-        classic_estimator = ClassicBValueEstimator()
-
-        return classic_estimator.calculate(self.magnitudes,
-                                           mc=self.dmc,
-                                           delta_m=self.delta_m,
-                                           weights=self.weights)
+        return _mle_estimator(self.magnitudes,
+                              mc=self.dmc,
+                              delta_m=self.delta_m,
+                              weights=self.weights)

--- a/seismostats/analysis/bvalue/utsu.py
+++ b/seismostats/analysis/bvalue/utsu.py
@@ -6,7 +6,7 @@ from seismostats.analysis.bvalue.utils import beta_to_b_value
 
 class UtsuBValueEstimator(BValueEstimator):
     '''
-    Estimator for the b-value using the maximum likelihood estimator.
+    Estimator for the b-value.
 
     Source:
         Utsu 1965 (Geophysical bulletin of the Hokkaido University,


### PR DESCRIPTION
1. Extract MLE estimator from tinti, in order to use it in the positive estimators.
2. Slightly change the way the `estimate` method is called:
    - When creating a new estimator with additional args, the `calculate` methods needs to be overwritten. In this new `calculate` method, the additional args can be checked and set as class attributes, and then the `super().calculate` method gets called.
    - If the additional args are arrays of the same size as `magnitudes`, the `_filter_magnitudes` method can similarly be overwritten. Calling the `super()._filter_magnitudes()` returns the indexes of the preserved magnitudes, which can be used to filter the additional array (eg. `times` in the case of the positive a value methods).