### PR TITLE
Bug/b value estimation

### DIFF
--- a/notebooks/manual.ipynb
+++ b/notebooks/manual.ipynb
@@ -5,7 +5,7 @@
    "id": "e05f2ba4",
    "metadata": {},
    "source": [
-    "# SeismoStats: How To\n",
+    "\\# SeismoStats: How To\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "\n",
     "#### In this notebook we will show how to:\n",
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "0e98ffda",
    "metadata": {},
    "outputs": [],
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "8ce71245",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "922bb4a9",
    "metadata": {},
    "outputs": [],
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "5bf99c7a",
    "metadata": {
     "scrolled": false
@@ -279,7 +279,7 @@
        "2791  0.8243519995  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -868,14 +868,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "fbe25210",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from seismostats.analysis.b_significant import mac_1D_constant_nm\n",
+    "from seismostats.analysis.b_significant import b_significant_1D\n",
     "from seismostats import bin_to_precision\n",
-    "from seismostats.plots.statistical import plot_b_series_constant_nm, plot_nm_vs_mac1D\n",
+    "from seismostats.plots.statistical import plot_b_series_constant_nm, plot_b_significant_1D\n",
     "from scipy.stats import norm\n",
     "\n",
     "from seismostats.analysis.bvalue import BPositiveBValueEstimator"
@@ -883,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "0f201717",
    "metadata": {},
    "outputs": [],
@@ -898,7 +898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "abc1c52e",
    "metadata": {},
    "outputs": [
@@ -908,7 +908,7 @@
        "Text(0.5, 0, 'Time')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -947,32 +947,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "8bf33c97",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/aron/polybox/Projects/SeismoStats/env/lib/python3.11/site-packages/seismostats/analysis/b_significant.py:337: UserWarning: The number of subsamples is less than 25. The normality assumption of the autocorrelation might not be valid.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "n_m = 100\n",
     "\n",
     "idx = mags >= mc\n",
-    "mac, mu_mac, std_mac = mac_1D_constant_nm(mags[idx], mc, delta_m, times[idx], n_m)\n",
+    "p, mac, mu_mac, std_mac = b_significant_1D(mags[idx], mc, delta_m, times[idx], n_m)\n",
     "\n",
     "# b-positive\n",
-    "mac, mu_mac, std_mac = mac_1D_constant_nm(mags[idx], mc, delta_m, times[idx], n_m, b_method= BPositiveBValueEstimator)\n"
+    "p, mac, mu_mac, std_mac = b_significant_1D(mags[idx], mc, delta_m, times[idx], n_m, method= BPositiveBValueEstimator)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "id": "9ef1fae6",
    "metadata": {},
    "outputs": [
@@ -980,14 +971,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The p-value of a constant b-value hypothesis is 0.16\n",
+      "The p-value of a constant b-value hypothesis is 0.13\n",
       "This is significantly larger than our threshold of 0.05. Therefore, we cannot reject the null-hypothesis\n"
      ]
     }
    ],
    "source": [
     "p_threshold = 0.05\n",
-    "p = 1 - norm(loc=mu_mac, scale=std_mac).cdf(mac)\n",
     "print('The p-value of a constant b-value hypothesis is {:.2f}'.format(p))\n",
     "print('This is significantly larger than our threshold of {:.2f}. Therefore, we cannot reject the null-hypothesis'.format(p_threshold))"
    ]
@@ -1000,6 +990,26 @@
     "<font color=#208de2> We found that the temporal variation was not significant, therefore further interpretation of how the b-value changes with time might not be reasonable to do. But this was specifically using a certain number of magnitudes per estimate. Maybe there is some other scale, where the b-value does change significantly?\n",
     "\n",
     "We can test this easily by applying the same method with different n_m. </font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "c8d2a1ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The z-value of the p-value is 1.96\n"
+     ]
+    }
+   ],
+   "source": [
+    "# find z value for p-value\n",
+    "z = norm.ppf(1 - p_threshold/2)\n",
+    "print('The z-value of the p-value is {:.2f}'.format(z))\n"
    ]
   },
   {
@@ -1038,10 +1048,10 @@
     }
    ],
    "source": [
-    "ax = plot_nm_vs_mac1D(\n",
+    "ax = plot_b_significant_1D(\n",
     "    mags, times, mc, delta_m, x_variable = times, color = '#1f77b4')\n",
     "\n",
-    "ax = plot_nm_vs_mac1D(\n",
+    "ax = plot_b_significant_1D(\n",
     "    mags, times, mc, delta_m, x_variable = times, color = '#1f77b4')\n"
    ]
   },

--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -79,7 +79,7 @@ class AValueEstimator(ABC):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        self.idx = np.where(self.magnitudes >= self.mc - self.delta_m / 2)[0]
+        self.idx = (self.magnitudes >= self.mc - self.delta_m / 2).nonzero()[0]
         self.magnitudes = self.magnitudes[self.idx]
 
         if len(self.magnitudes) == 0:
@@ -92,7 +92,8 @@ class AValueEstimator(ABC):
         '''
         # test magnitude binnning
         if len(self.magnitudes) > 0:
-            if not binning_test(self.magnitudes, self.delta_m,
+            tolerance = 1e-8
+            if not binning_test(self.magnitudes, max(self.delta_m, tolerance),
                                 check_larger_binning=False):
                 raise ValueError('Magnitudes are not binned correctly.')
 

--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -92,8 +92,7 @@ class AValueEstimator(ABC):
         '''
         # test magnitude binnning
         if len(self.magnitudes) > 0:
-            tolerance = 1e-8
-            if not binning_test(self.magnitudes, max(self.delta_m, tolerance),
+            if not binning_test(self.magnitudes, self.delta_m,
                                 check_larger_binning=False):
                 raise ValueError('Magnitudes are not binned correctly.')
 

--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -75,36 +75,32 @@ class AValueEstimator(ABC):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        idx = np.where(self.magnitudes >= self.mc - self.delta_m / 2)[0]
-        self.magnitudes = self.magnitudes[idx]
+        self.idx = np.where(self.magnitudes >= self.mc - self.delta_m / 2)[0]
+        self.magnitudes = self.magnitudes[self.idx]
 
-        assert (
-            len(self.magnitudes) > 0
-        )
-        'No magnitudes above the completeness magnitude.'
+        if len(self.magnitudes) == 0:
+            raise ValueError('No magnitudes above the completeness magnitude.')
 
-        self.idx = idx
-        return idx
+        return self.idx
 
     def _sanity_checks(self):
         '''
         Perform sanity checks on the input data.
         '''
+        # test magnitude binnning
+        if not binning_test(self.magnitudes, self.delta_m,
+                            check_larger_binning=False):
+            raise ValueError('Magnitudes are not binned correctly.')
 
-        if np.any(np.isnan(self.magnitudes)):
-            raise ValueError('Magnitudes contain NaN values.')
-        assert (
-            binning_test(self.magnitudes, self.delta_m,
-                         check_larger_binning=False)
-        )
-        'Magnitudes are not binned correctly.'
-
+        # give warnings
         if get_option('warnings') is True:
             if np.min(self.magnitudes) - self.mc > self.delta_m / 2:
                 warnings.warn(
                     'No magnitudes in the lowest magnitude bin are present. '
                     'Check if mc is chosen correctly.'
                 )
+            if np.any(np.isnan(self.magnitudes)):
+                warnings.warn('Magnitudes contain NaN values.')
 
     def _reference_scaling(self, a: float) -> float:
         '''

--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -59,6 +59,10 @@ class AValueEstimator(ABC):
         self._sanity_checks()
         self._filter_magnitudes()
 
+        if len(self.magnitudes) == 0:
+            self.__a_value = np.nan
+            return self.__a_value
+
         self.__a_value = self._estimate()
         self.__a_value = self._reference_scaling(self.__a_value)
 
@@ -79,28 +83,26 @@ class AValueEstimator(ABC):
         self.magnitudes = self.magnitudes[self.idx]
 
         if len(self.magnitudes) == 0:
-            raise ValueError('No magnitudes above the completeness magnitude.')
-
-        return self.idx
+            if get_option('warnings') is True:
+                warnings.warn('No magnitudes above the completeness magnitude.')
 
     def _sanity_checks(self):
         '''
         Perform sanity checks on the input data.
         '''
         # test magnitude binnning
-        if not binning_test(self.magnitudes, self.delta_m,
-                            check_larger_binning=False):
-            raise ValueError('Magnitudes are not binned correctly.')
+        if len(self.magnitudes) > 0:
+            if not binning_test(self.magnitudes, self.delta_m,
+                                check_larger_binning=False):
+                raise ValueError('Magnitudes are not binned correctly.')
 
-        # give warnings
-        if get_option('warnings') is True:
-            if np.min(self.magnitudes) - self.mc > self.delta_m / 2:
-                warnings.warn(
-                    'No magnitudes in the lowest magnitude bin are present. '
-                    'Check if mc is chosen correctly.'
-                )
-            if np.any(np.isnan(self.magnitudes)):
-                warnings.warn('Magnitudes contain NaN values.')
+            # give warnings
+            if get_option('warnings') is True:
+                if np.min(self.magnitudes) - self.mc > self.delta_m / 2:
+                    warnings.warn(
+                        'No magnitudes in the lowest magnitude bin are present.'
+                        'Check if mc is chosen correctly.'
+                    )
 
     def _reference_scaling(self, a: float) -> float:
         '''

--- a/seismostats/analysis/avalue/more_positive.py
+++ b/seismostats/analysis/avalue/more_positive.py
@@ -79,7 +79,6 @@ class AMorePositiveAValueEstimator(AValueEstimator):
         '''
         super()._filter_magnitudes()
         self.times = self.times[self.idx]
-        return self.idx
 
     def _estimate(self) -> float:
         # order the magnitudes and times

--- a/seismostats/analysis/avalue/more_positive.py
+++ b/seismostats/analysis/avalue/more_positive.py
@@ -73,7 +73,7 @@ class AMorePositiveAValueEstimator(AValueEstimator):
                                  b_value=b_value,
                                  )
 
-    def _filter_magnitudes(self):
+    def _filter_magnitudes(self) -> np.ndarray:
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
@@ -88,8 +88,9 @@ class AMorePositiveAValueEstimator(AValueEstimator):
         srt = np.argsort(self.times)
         self.magnitudes = self.magnitudes[srt]
         self.times = self.times[srt]
+        self.idx = self.idx[srt]
 
-        # differences
+        # find next larger event (if it exists)
         idx_next_larger = find_next_larger(
             self.magnitudes, self.delta_m, self.dmc)
         time_diffs = self.times[idx_next_larger] - self.times
@@ -107,6 +108,12 @@ class AMorePositiveAValueEstimator(AValueEstimator):
 
         time_factor = sum(tau / total_time)
         n_more_pos = sum(~idx_no_next) / time_factor
+
+        # make sure that all attributes are consistent
+        idx_next_larger = idx_next_larger[~idx_no_next]
+        self.magnitudes = self.magnitudes[idx_next_larger]
+        self.times = self.times[idx_next_larger]
+        self.idx = self.idx[idx_next_larger]
 
         # estimate a-value
         return np.log10(n_more_pos)

--- a/seismostats/analysis/avalue/more_positive.py
+++ b/seismostats/analysis/avalue/more_positive.py
@@ -77,11 +77,9 @@ class AMorePositiveAValueEstimator(AValueEstimator):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        idx = super()._filter_magnitudes()
-
-        self.times = self.times[idx]
-
-        return idx
+        super()._filter_magnitudes()
+        self.times = self.times[self.idx]
+        return self.idx
 
     def _estimate(self) -> float:
         # order the magnitudes and times

--- a/seismostats/analysis/avalue/positive.py
+++ b/seismostats/analysis/avalue/positive.py
@@ -78,7 +78,6 @@ class APositiveAValueEstimator(AValueEstimator):
         '''
         super()._filter_magnitudes()
         self.times = self.times[self.idx]
-        return self.idx
 
     def _estimate(self) -> float:
         # order the magnitudes and times

--- a/seismostats/analysis/avalue/positive.py
+++ b/seismostats/analysis/avalue/positive.py
@@ -76,11 +76,9 @@ class APositiveAValueEstimator(AValueEstimator):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        idx = super()._filter_magnitudes()
-
-        self.times = self.times[idx]
-
-        return idx
+        super()._filter_magnitudes()
+        self.times = self.times[self.idx]
+        return self.idx
 
     def _estimate(self) -> float:
         # order the magnitudes and times

--- a/seismostats/analysis/avalue/positive.py
+++ b/seismostats/analysis/avalue/positive.py
@@ -83,26 +83,29 @@ class APositiveAValueEstimator(AValueEstimator):
         return idx
 
     def _estimate(self) -> float:
-
         # order the magnitudes and times
-        idx = np.argsort(self.times)
-        self.magnitudes = self.magnitudes[idx]
-        self.times = self.times[idx]
+        srt = np.argsort(self.times)
+        self.magnitudes = self.magnitudes[srt]
+        self.times = self.times[srt]
+        self.idx = self.idx[srt]
 
         # differences
         mag_diffs = np.diff(self.magnitudes)
         time_diffs = np.diff(self.times)
 
         # only consider events with magnitude difference >= dmc
-        idx = mag_diffs > self.dmc - self.delta_m / 2
-        mag_diffs = mag_diffs[idx]
-        time_diffs = time_diffs[idx]
+        is_larger = mag_diffs >= self.dmc - self.delta_m / 2
+        mag_diffs = mag_diffs[is_larger]
+        time_diffs = time_diffs[is_larger]
+        self.magnitudes = self.magnitudes[1:][is_larger]
+        self.idx = self.idx[1:][is_larger]
 
         # estimate the number of events within the time interval
         total_time = self.times[-1] - self.times[0]
+        self.times = self.times[1:][is_larger]
 
         time_factor = sum(time_diffs / total_time)
-        n_pos = sum(idx) / time_factor
+        n_pos = sum(is_larger) / time_factor
 
         # estimate a-value
         return np.log10(n_pos)

--- a/seismostats/analysis/avalue/positive.py
+++ b/seismostats/analysis/avalue/positive.py
@@ -95,7 +95,6 @@ class APositiveAValueEstimator(AValueEstimator):
 
         # only consider events with magnitude difference >= dmc
         is_larger = mag_diffs >= self.dmc - self.delta_m / 2
-        mag_diffs = mag_diffs[is_larger]
         time_diffs = time_diffs[is_larger]
         self.magnitudes = self.magnitudes[1:][is_larger]
         self.idx = self.idx[1:][is_larger]

--- a/seismostats/analysis/avalue/tests/test_avalue.py
+++ b/seismostats/analysis/avalue/tests/test_avalue.py
@@ -101,6 +101,7 @@ def test_estimate_a_positive():
                       datetime(2000, 1, 5)])
     estimator.calculate(mags, mc=-1, delta_m=0.1, times=times)
     assert (mags[estimator.idx] == np.array([0.9, 0.2, 0.5])).all()
+    assert (mags[estimator.idx] == estimator.magnitudes).all()
 
     # test that time array is correctly used
     mags = np.array([0, 0.9, 0.5, 0.2, -1])
@@ -111,6 +112,7 @@ def test_estimate_a_positive():
                       datetime(2000, 1, 3)])
     estimator.calculate(mags, mc=-1, delta_m=0.1, times=times)
     assert (mags[estimator.idx] == np.array([0.9, 0.2, 0.5])).all()
+    assert (mags[estimator.idx] == estimator.magnitudes).all()
 
 
 @pytest.mark.filterwarnings("ignore")
@@ -142,3 +144,29 @@ def test_estimate_a_more_positive():
     a = estimator.calculate(
         mags, 0, 0.1, times, b_value=1, dmc=0.1)
     assert_almost_equal(10**a, 16.0)
+
+    # test that index works correctly
+    mags = np.array([0, 0.9, -1, 0.2, 0.5, 1])
+    times = np.array([datetime(2000, 1, 1),
+                      datetime(2000, 1, 2),
+                      datetime(2000, 1, 3),
+                      datetime(2000, 1, 4),
+                      datetime(2000, 1, 5),
+                      datetime(2000, 1, 6)])
+    estimator.calculate(mags, mc=-1, delta_m=0.1, times=times, b_value=1)
+    assert (mags[estimator.idx] == np.array([0.9, 1, 0.2, 0.5, 1])).all()
+    assert (estimator.idx == np.array([1, 5, 3, 4, 5])).all()
+    assert (mags[estimator.idx] == estimator.magnitudes).all()
+    assert (estimator.times == times[estimator.idx]).all()
+
+    # test that time array is correctly used
+    mags = np.array([0, 0.9, 0.5, 0.2, -1])
+    times = np.array([datetime(2000, 1, 1),
+                      datetime(2000, 1, 2),
+                      datetime(2000, 1, 5),
+                      datetime(2000, 1, 4),
+                      datetime(2000, 1, 3)])
+    estimator.calculate(mags, mc=-1, delta_m=0.1, times=times, b_value=1)
+    assert (mags[estimator.idx] == np.array([0.9, 0.2, 0.5])).all()
+    assert (mags[estimator.idx] == estimator.magnitudes).all()
+    assert (estimator.times == times[estimator.idx]).all()

--- a/seismostats/analysis/avalue/tests/test_avalue.py
+++ b/seismostats/analysis/avalue/tests/test_avalue.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import warnings
 
 import numpy as np
 import pytest
@@ -42,9 +41,8 @@ def test_estimate_a_classic():
     assert a_estimate == 1.0
 
     # reference magnitude is given and b-value given
-    with warnings.catch_warnings(record=True):
-        a_estimate = estimator.calculate(mags, mc=1, delta_m=0.0,
-                                         m_ref=0, b_value=1)
+    a_estimate = estimator.calculate(mags, mc=1, delta_m=0.0,
+                                     m_ref=0, b_value=1)
     assert a_estimate == 2.0
 
     # reference magnitude but no b-value

--- a/seismostats/analysis/avalue/tests/test_base.py
+++ b/seismostats/analysis/avalue/tests/test_base.py
@@ -9,7 +9,7 @@ def test_estimate_a_warnings():
     mags = simulate_magnitudes_binned(n=100, b=1, mc=0, delta_m=0.1)
 
     # test that uncorrect binninng leads to error
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         estimator = ClassicAValueEstimator()
         estimator.calculate(mags, mc=0, delta_m=0.2)
 
@@ -25,7 +25,7 @@ def test_estimate_a_warnings():
 
     # No magnitudes above completeness magnitude
     mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         estimator.calculate(mags, mc=1, delta_m=0.1)
 
 

--- a/seismostats/analysis/avalue/tests/test_base.py
+++ b/seismostats/analysis/avalue/tests/test_base.py
@@ -8,23 +8,39 @@ from seismostats.utils.simulate_distributions import simulate_magnitudes_binned
 def test_estimate_a_warnings():
     mags = simulate_magnitudes_binned(n=100, b=1, mc=0, delta_m=0.1)
 
-    # TODO: test that uncorrect binninng leads to error
-    # with pytest.raises(AssertionError):
-    #     estimator = ClassicAValueEstimator()
-    #     estimator.calculate(mags, mc=0, delta_m=0.2)
+    # test that uncorrect binninng leads to error
+    with pytest.raises(AssertionError):
+        estimator = ClassicAValueEstimator()
+        estimator.calculate(mags, mc=0, delta_m=0.2)
 
     # test that warning is raised if smallest magnitude is much larger than mc
     with pytest.warns(UserWarning):
         estimator = ClassicAValueEstimator()
         estimator.calculate(mags, mc=-1, delta_m=0.1)
 
+    # Magnitudes contain NaN values
+    mags = np.array([np.nan])
+    with pytest.raises(ValueError):
+        estimator.calculate(mags, mc=1, delta_m=0.1)
+
+    # No magnitudes above completeness magnitude
+    mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
+    with pytest.raises(AssertionError):
+        estimator.calculate(mags, mc=1, delta_m=0.1)
+
 
 def test_by_reference():
-    mags = simulate_magnitudes_binned(n=100, b=1, mc=0, delta_m=0.1)
     estimator = ClassicAValueEstimator()
+
+    mags = simulate_magnitudes_binned(n=100, b=1, mc=0, delta_m=0.1)
     estimator.calculate(mags, mc=0, delta_m=0.1)
     estimator.magnitudes.sort()
     assert not np.array_equal(mags, estimator.magnitudes)
+
+    # test index is working
+    mags = np.array([0, 0.9, -1, 0.2, 0.5])
+    estimator.calculate(mags, mc=0.1, delta_m=0.1)
+    assert (estimator.magnitudes == mags[estimator.idx]).all()
 
 
 def test_reference_scaling():

--- a/seismostats/analysis/avalue/tests/test_base.py
+++ b/seismostats/analysis/avalue/tests/test_base.py
@@ -19,14 +19,17 @@ def test_estimate_a_warnings():
         estimator.calculate(mags, mc=-1, delta_m=0.1)
 
     # Magnitudes contain NaN values
-    mags = np.array([np.nan])
-    with pytest.raises(ValueError):
-        estimator.calculate(mags, mc=1, delta_m=0.1)
+    mags1 = np.array([np.nan, 1, 2, 3, 4])
+    a1 = estimator.calculate(mags1, mc=1, delta_m=1)
+    mags2 = np.array([1, 2, 3, 4])
+    a2 = estimator.calculate(mags2, mc=1, delta_m=1)
+    assert (a1 == a2)
 
     # No magnitudes above completeness magnitude
     mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         estimator.calculate(mags, mc=1, delta_m=0.1)
+    assert (np.isnan(estimator.a_value))
 
 
 def test_by_reference():

--- a/seismostats/analysis/b_significant.py
+++ b/seismostats/analysis/b_significant.py
@@ -280,7 +280,7 @@ def b_significant_1D(
         n_m:            Number of magnitudes in each partition.
         min_num:        Minimum number of events in a partition.
         b_method:       Method to estimate the b-values.
-        return_p:       If True, the p-value of the null hypothesis of constant 
+        return_p:       If True, the p-value of the null hypothesis of constant
                     b-values is returned.
         conservative:   If True, the conservative estimate of the standard
                     deviation of the autocorrelation is used, i.e., gamma = 1.

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -44,8 +44,8 @@ class BValueEstimator(ABC):
         self.delta_m = delta_m
         self.weights = None if weights is None else np.array(weights)
 
-        self._filter_magnitudes()
         self._sanity_checks()
+        self._filter_magnitudes()
 
         self.__b_value = self._estimate()
         return self.__b_value
@@ -67,20 +67,28 @@ class BValueEstimator(ABC):
         if self.weights is not None:
             self.weights = self.weights[idx]
 
+        assert (
+            len(self.magnitudes) > 0
+        )
+        'No magnitudes above the completeness magnitude.'
+
         return idx
 
     def _sanity_checks(self):
         '''
         Perform sanity checks on the input data.
         '''
+        if np.any(np.isnan(self.magnitudes)):
+            raise ValueError('Magnitudes contain NaN values.')
 
-        # test that the magnitudes are binned correctly
+        # test magnitude binnning
         if self.delta_m == 0:
             tolerance = 1e-08
         else:
             tolerance = max(self.delta_m / 100, 1e-08)
         assert (
-            binning_test(self.magnitudes, self.delta_m, tolerance)
+            binning_test(self.magnitudes, self.delta_m,
+                         tolerance, check_larger_binning=False)
         )
         'Magnitudes are not binned correctly.'
 

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -81,8 +81,7 @@ class BValueEstimator(ABC):
         '''
         # test magnitude binnning
         if len(self.magnitudes) > 0:
-            tolerance = 1e-8
-            if not binning_test(self.magnitudes, max(self.delta_m, tolerance),
+            if not binning_test(self.magnitudes, self.delta_m,
                                 check_larger_binning=False):
                 raise ValueError('Magnitudes are not binned correctly.')
 

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -65,7 +65,7 @@ class BValueEstimator(ABC):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        self.idx = np.where(self.magnitudes >= self.mc - self.delta_m / 2)[0]
+        self.idx = (self.magnitudes >= self.mc - self.delta_m / 2).nonzero()[0]
         self.magnitudes = self.magnitudes[self.idx]
 
         if self.weights is not None:
@@ -81,7 +81,8 @@ class BValueEstimator(ABC):
         '''
         # test magnitude binnning
         if len(self.magnitudes) > 0:
-            if not binning_test(self.magnitudes, self.delta_m,
+            tolerance = 1e-8
+            if not binning_test(self.magnitudes, max(self.delta_m, tolerance),
                                 check_larger_binning=False):
                 raise ValueError('Magnitudes are not binned correctly.')
 

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -61,7 +61,7 @@ class BValueEstimator(ABC):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        idx = self.magnitudes >= self.mc - self.delta_m / 2
+        idx = np.where(self.magnitudes >= self.mc - self.delta_m / 2)[0]
         self.magnitudes = self.magnitudes[idx]
 
         if self.weights is not None:
@@ -72,6 +72,7 @@ class BValueEstimator(ABC):
         )
         'No magnitudes above the completeness magnitude.'
 
+        self.idx = idx
         return idx
 
     def _sanity_checks(self):
@@ -82,13 +83,9 @@ class BValueEstimator(ABC):
             raise ValueError('Magnitudes contain NaN values.')
 
         # test magnitude binnning
-        if self.delta_m == 0:
-            tolerance = 1e-08
-        else:
-            tolerance = max(self.delta_m / 100, 1e-08)
         assert (
             binning_test(self.magnitudes, self.delta_m,
-                         tolerance, check_larger_binning=False)
+                         check_larger_binning=False)
         )
         'Magnitudes are not binned correctly.'
 

--- a/seismostats/analysis/bvalue/more_positive.py
+++ b/seismostats/analysis/bvalue/more_positive.py
@@ -48,11 +48,8 @@ class BMorePositiveBValueEstimator(BValueEstimator):
                     this value are not considered). If None, the cutoff is set
                     to delta_m.
         '''
-        if times is None:
-            self.times = None
-        else:
-            self.times: np.ndarray = np.array(times)
-
+        self.times: np.ndarray | None = np.array(
+            times) if times is not None else times
         self.dmc: float = dmc if dmc is not None else delta_m
 
         if self.dmc < 0:
@@ -70,11 +67,10 @@ class BMorePositiveBValueEstimator(BValueEstimator):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        idx = super()._filter_magnitudes()
-
+        super()._filter_magnitudes()
         if self.times is not None:
-            self.times = self.times[idx]
-        return idx
+            self.times = self.times[self.idx]
+        return self.idx
 
     def _estimate(self) -> float:
         if self.times is not None:

--- a/seismostats/analysis/bvalue/more_positive.py
+++ b/seismostats/analysis/bvalue/more_positive.py
@@ -70,7 +70,6 @@ class BMorePositiveBValueEstimator(BValueEstimator):
         super()._filter_magnitudes()
         if self.times is not None:
             self.times = self.times[self.idx]
-        return self.idx
 
     def _estimate(self) -> float:
         if self.times is not None:

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -67,7 +67,6 @@ class BPositiveBValueEstimator(BValueEstimator):
         super()._filter_magnitudes()
         if self.times is not None:
             self.times = self.times[self.idx]
-        return self.idx
 
     def _estimate(self) -> float:
         # order the magnitudes and times

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -26,21 +26,29 @@ class BPositiveBValueEstimator(BValueEstimator):
                   magnitudes: np.ndarray,
                   mc: float,
                   delta_m: float,
+                  times: np.ndarray | None = None,
                   weights: np.ndarray | None = None,
                   dmc: float | None = None) -> float:
         '''
-        Return the b-value estimate calculated using the
+        Returns the b-value estimate calculated using the
         positive differences between consecutive magnitudes.
 
         Args:
             magnitudes: Array of magnitudes
             mc:         Completeness magnitude
             delta_m:    Discretization of magnitudes.
+            times:      Vector of times of the events, in any format (datetime,
+                    float, etc.). If None, it is assumed that the events are
+                    ordered in time.
             weights:    Array of weights for the magnitudes.
-            dmc:        Cutoff value for the differences (differences
-                        below this value are not considered). If None,
-                        the cutoff is set to delta_m.
+            dmc:        Cutoff value for the differences (differences below
+                    this value are not considered). If None, the cutoff is set
+                    to delta_m.
         '''
+        if times is None:
+            self.times = None
+        else:
+            self.times: np.ndarray = np.array(times)
 
         self.dmc: float = dmc if dmc is not None else delta_m
 
@@ -55,17 +63,37 @@ class BPositiveBValueEstimator(BValueEstimator):
                                  delta_m=delta_m,
                                  weights=weights)
 
-    def _estimate(self, dmc: float | None = None) -> float:
+    def _filter_magnitudes(self) -> np.ndarray:
+        '''
+        Filter out magnitudes below the completeness magnitude.
+        '''
+        idx = super()._filter_magnitudes()
 
-        # only take the values where the next earthquake is d_mc larger than the
-        # previous one. delta_m / 2 is added to avoid numerical errors
+        if self.times is not None:
+            self.times = self.times[idx]
+        return idx
+
+    def _estimate(self) -> float:
+        # order the magnitudes and times
+        if self.times is not None:
+            srt = np.argsort(self.times)
+            self.magnitudes = self.magnitudes[srt]
+            self.times = self.times[srt]
+            if self.weights is not None:
+                self.weights = self.weights[srt]
+            self.idx = self.idx[srt]
+
+        # calculate differences, only keep positive ones
         self.magnitudes = np.diff(self.magnitudes)
         is_larger = self.magnitudes >= self.dmc - self.delta_m / 2
-        self.magnitudes = abs(self.magnitudes[is_larger])
+        self.magnitudes = self.magnitudes[is_larger]
+        self.idx = self.idx[1:][is_larger]
 
         if self.weights is not None:
             # use weight of second earthquake of a difference
             self.weights = self.weights[1:][is_larger]
+        if self.times is not None:
+            self.times = self.times[1:][is_larger]
 
         return _mle_estimator(self.magnitudes,
                               mc=self.dmc,

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -45,11 +45,8 @@ class BPositiveBValueEstimator(BValueEstimator):
                     this value are not considered). If None, the cutoff is set
                     to delta_m.
         '''
-        if times is None:
-            self.times = None
-        else:
-            self.times: np.ndarray = np.array(times)
-
+        self.times: np.ndarray | None = np.array(
+            times) if times is not None else times
         self.dmc: float = dmc if dmc is not None else delta_m
 
         if self.dmc < 0:
@@ -67,11 +64,10 @@ class BPositiveBValueEstimator(BValueEstimator):
         '''
         Filter out magnitudes below the completeness magnitude.
         '''
-        idx = super()._filter_magnitudes()
-
+        super()._filter_magnitudes()
         if self.times is not None:
-            self.times = self.times[idx]
-        return idx
+            self.times = self.times[self.idx]
+        return self.idx
 
     def _estimate(self) -> float:
         # order the magnitudes and times

--- a/seismostats/analysis/bvalue/positive.py
+++ b/seismostats/analysis/bvalue/positive.py
@@ -58,9 +58,9 @@ class BPositiveBValueEstimator(BValueEstimator):
     def _estimate(self, dmc: float | None = None) -> float:
 
         # only take the values where the next earthquake is d_mc larger than the
-        # previous one. delta_m is added to avoid numerical errors
+        # previous one. delta_m / 2 is added to avoid numerical errors
         self.magnitudes = np.diff(self.magnitudes)
-        is_larger = self.magnitudes > self.dmc - self.delta_m / 2
+        is_larger = self.magnitudes >= self.dmc - self.delta_m / 2
         self.magnitudes = abs(self.magnitudes[is_larger])
 
         if self.weights is not None:

--- a/seismostats/analysis/bvalue/tests/test_base.py
+++ b/seismostats/analysis/bvalue/tests/test_base.py
@@ -11,7 +11,7 @@ def test_estimate_b_warnings():
     mags = simulate_magnitudes_binned(n=100, b=1, mc=0, delta_m=0.1)
 
     # test that uncorrect binninng leads to error
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         estimator = ClassicBValueEstimator()
         estimator.calculate(mags, mc=0, delta_m=0.2)
 
@@ -27,7 +27,7 @@ def test_estimate_b_warnings():
 
     # No magnitudes above completeness magnitude
     mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         estimator.calculate(mags, mc=1, delta_m=0.1)
 
 

--- a/seismostats/analysis/bvalue/tests/test_base.py
+++ b/seismostats/analysis/bvalue/tests/test_base.py
@@ -21,14 +21,18 @@ def test_estimate_b_warnings():
         estimator.calculate(mags, mc=-1, delta_m=0.1)
 
     # Magnitudes contain NaN values
-    mags = np.array([np.nan])
-    with pytest.raises(ValueError):
-        estimator.calculate(mags, mc=1, delta_m=0.1)
+    mags1 = np.array([np.nan, 1, 2, 3, 4])
+    b1 = estimator.calculate(mags1, mc=1, delta_m=1)
+    mags2 = np.array([1, 2, 3, 4])
+    b2 = estimator.calculate(mags2, mc=1, delta_m=1)
+    assert (b1 == b2)
 
     # No magnitudes above completeness magnitude
     mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
-    with pytest.raises(ValueError):
+    # make sure that warning is raised
+    with pytest.warns(UserWarning):
         estimator.calculate(mags, mc=1, delta_m=0.1)
+    assert (np.isnan(estimator.b_value))
 
 
 def test_by_reference():

--- a/seismostats/analysis/bvalue/tests/test_base.py
+++ b/seismostats/analysis/bvalue/tests/test_base.py
@@ -20,6 +20,16 @@ def test_estimate_b_warnings():
         estimator = ClassicBValueEstimator()
         estimator.calculate(mags, mc=-1, delta_m=0.1)
 
+    # Magnitudes contain NaN values
+    mags = np.array([np.nan])
+    with pytest.raises(ValueError):
+        estimator.calculate(mags, mc=1, delta_m=0.1)
+
+    # No magnitudes above completeness magnitude
+    mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
+    with pytest.raises(AssertionError):
+        estimator.calculate(mags, mc=1, delta_m=0.1)
+
 
 def test_by_reference():
     estimator = ClassicBValueEstimator()
@@ -31,21 +41,10 @@ def test_by_reference():
     estimator.magnitudes.sort()
     assert not np.array_equal(mags, estimator.magnitudes)
 
-    # Magnitudes contain NaN values
-    mags = np.array([np.nan])
-    with pytest.raises(ValueError):
-        estimator.calculate(mags, mc=1, delta_m=0.1)
-
-    # No magnitudes above completeness magnitude
-    mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
-    with pytest.raises(AssertionError):
-        estimator.calculate(mags, mc=1, delta_m=0.1)
-
-    # test index
-    mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
-    estimator.calculate(mags, mc=0, delta_m=0.1)
-    print(estimator.index)
-    assert estimator.index == np.array([0])
+    # test index is working
+    mags = np.array([0, 0.9, -1, 0.2, 0.5])
+    estimator.calculate(mags, mc=0.1, delta_m=0.1)
+    assert (estimator.magnitudes == mags[estimator.idx]).all()
 
 
 def test_beta():

--- a/seismostats/analysis/bvalue/tests/test_base.py
+++ b/seismostats/analysis/bvalue/tests/test_base.py
@@ -22,11 +22,30 @@ def test_estimate_b_warnings():
 
 
 def test_by_reference():
-    mags = simulate_magnitudes_binned(n=100, b=1, mc=0, delta_m=0.1)
     estimator = ClassicBValueEstimator()
+
+    # test that values below mc are filtered out
+    mags = np.array([0, 1, 3.1, 1.1, 2, 1.2, 1.3, 1.4,
+                    4.7, 1.5, 1.6, 1.7, 1.8, 3.4])
     estimator.calculate(mags, mc=1, delta_m=0.1)
     estimator.magnitudes.sort()
     assert not np.array_equal(mags, estimator.magnitudes)
+
+    # Magnitudes contain NaN values
+    mags = np.array([np.nan])
+    with pytest.raises(ValueError):
+        estimator.calculate(mags, mc=1, delta_m=0.1)
+
+    # No magnitudes above completeness magnitude
+    mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
+    with pytest.raises(AssertionError):
+        estimator.calculate(mags, mc=1, delta_m=0.1)
+
+    # test index
+    mags = np.array([0, 0.9, 0.1, 0.2, 0.5])
+    estimator.calculate(mags, mc=0, delta_m=0.1)
+    print(estimator.index)
+    assert estimator.index == np.array([0])
 
 
 def test_beta():

--- a/seismostats/analysis/bvalue/tests/test_bvalues.py
+++ b/seismostats/analysis/bvalue/tests/test_bvalues.py
@@ -215,3 +215,22 @@ def test_estimate_b_more_positive(
     assert_almost_equal(b_estimate, b_est_correct)
     assert_almost_equal(b_estimate, b_estimate_weighted)
     assert_almost_equal(b_estimate, b_estimate_half_weighted)
+
+    # test that index works correctly
+    mags = np.array([0, 0.9, -1, 0.2, 0.5, 1])
+    estimator.calculate(mags, mc=-1, delta_m=0.1)
+    assert (mags[estimator.idx] == np.array([0.9, 1, 0.2, 0.5, 1])).all()
+    assert (estimator.idx == np.array([1, 5, 3, 4, 5])).all()
+    assert (estimator.times is None)
+
+    # test that time array is correctly used
+    mags = np.array([0, 0.9, 0.5, 0.2, -1])
+    times = np.array([datetime(2000, 1, 1),
+                      datetime(2000, 1, 2),
+                      datetime(2000, 1, 5),
+                      datetime(2000, 1, 4),
+                      datetime(2000, 1, 3)])
+
+    estimator.calculate(mags, mc=-1, delta_m=0.1, times=times)
+    assert (mags[estimator.idx] == np.array([0.9, 0.2, 0.5])).all()
+    assert (estimator.times == times[estimator.idx]).all()

--- a/seismostats/analysis/bvalue/tests/test_bvalues.py
+++ b/seismostats/analysis/bvalue/tests/test_bvalues.py
@@ -1,5 +1,6 @@
 import os
 
+from datetime import datetime
 import numpy as np
 import pandas as pd
 import pytest
@@ -158,6 +159,22 @@ def test_estimate_b_positive(
     assert_almost_equal(b_estimate, b_estimate_weighted)
     assert_almost_equal(b_estimate, b_estimate_half_weighted)
     assert_almost_equal(b_estimate, b_estimate_extended)
+
+    # test that index works correctly
+    mags = np.array([0, 0.9, -1, 0.2, 0.5])
+    estimator.calculate(mags, mc=-1, delta_m=0.1)
+    assert (mags[estimator.idx] == np.array([0.9, 0.2, 0.5])).all()
+
+    # test that time array is correctly used
+    mags = np.array([0, 0.9, 0.5, 0.2, -1])
+    times = np.array([datetime(2000, 1, 1),
+                      datetime(2000, 1, 2),
+                      datetime(2000, 1, 5),
+                      datetime(2000, 1, 4),
+                      datetime(2000, 1, 3)])
+
+    estimator.calculate(mags, mc=-1, delta_m=0.1, times=times)
+    assert (mags[estimator.idx] == np.array([0.9, 0.2, 0.5])).all()
 
 
 @pytest.mark.parametrize(

--- a/seismostats/analysis/bvalue/utils.py
+++ b/seismostats/analysis/bvalue/utils.py
@@ -93,7 +93,7 @@ def find_next_larger(magnitudes: np.array,
     for ii in range(len(magnitudes) - 1):
         for jj in range(ii + 1, len(magnitudes)):
             mag_diff_loop = magnitudes[jj] - magnitudes[ii]
-            if mag_diff_loop > dmc - delta_m / 2:
+            if mag_diff_loop >= dmc - delta_m / 2:
                 idx_next_larger[ii] = jj
                 break
     return idx_next_larger.astype(int)

--- a/seismostats/plots/statistical.py
+++ b/seismostats/plots/statistical.py
@@ -91,6 +91,7 @@ def plot_b_series_constant_nm(
         ax: plt.Axes | None = None,
         color: str = "blue",
         label: str | None = None,
+        *args,
         **kwargs,
 ) -> plt.Axes:
     """
@@ -119,12 +120,17 @@ def plot_b_series_constant_nm(
             the b-values are plotted against the event index.
         confidence:    confidence interval that should be plotted. Default
             is 0.95 (i.e., the 95% confidence interval is plotted)
-        ax:    axis where the plot should be plotted
-        color: color of the data
+        ax:     axis where the plot should be plotted
+        color:  color of the data
+        label:  abel of the data that will be put in the legend
+        *args:  Additional positional arguments for the b-value estimator.
+        **kwargs:   Additional keyword arguments for the b-value estimator.
 
     Returns:
         ax that was plotted on
     """
+    mags = np.array(mags)
+    times = np.array(times)
 
     if isinstance(mc, (float, int)):
         if min(mags) < mc:
@@ -135,21 +141,15 @@ def plot_b_series_constant_nm(
         if any(mags < mc):
             raise ValueError("There are earthquakes below their respective "
                              "completeness magnitude")
-
     if n_m < min_num:
         raise ValueError("n_m cannot be smaller than min_num")
-
-    if not isinstance(mags, np.ndarray):
-        raise ValueError("mags must be an array")
-    if not isinstance(times, np.ndarray):
-        raise ValueError("times must be an array")
     if len(mags) != len(times):
-        raise ValueError("mags and times must have the same length")
+        raise IndexError("mags and times must have the same length")
 
     if x_variable is None:
         x_variable = np.arange(len(mags))
     elif len(x_variable) != len(mags):
-        raise ValueError(
+        raise IndexError(
             "x_variable must have the same length as magnitudes")
     else:
         idx_sort = np.argsort(x_variable)
@@ -186,7 +186,8 @@ def plot_b_series_constant_nm(
         times_window = times_window[idx]
 
         # estimate the b-value
-        estimator.calculate(mags_window, mc=mc[ii], delta_m=delta_m, **kwargs)
+        estimator.calculate(
+            mags_window, mc=mc[ii], delta_m=delta_m, *args, **kwargs)
         if estimator.n < min_num:
             b_values[idx_start + ii] = np.nan
             std_bs[idx_start + ii] = np.nan

--- a/seismostats/utils/binning.py
+++ b/seismostats/utils/binning.py
@@ -109,6 +109,9 @@ def binning_test(
         raise ValueError("The given array has no entry")
     x = np.array(x)
 
+    # filter out NaN values
+    x = x[~np.isnan(x)]
+
     if delta_x == 0 and check_larger_binning is True:
         range = np.max(x) - np.min(x)
         power = np.arange(np.floor(np.log10(tolerance)) + 1,

--- a/seismostats/utils/binning.py
+++ b/seismostats/utils/binning.py
@@ -1,8 +1,5 @@
 import decimal
 import numpy as np
-import warnings
-
-from seismostats.utils._config import get_option
 
 
 def normal_round_to_int(x: float) -> int:
@@ -125,11 +122,7 @@ def binning_test(
 
     else:
         if delta_x < tolerance:
-            if get_option("warnings") is True:
-                warnings.warn(
-                    "delta_x is smaller than tolerance, checking"
-                    "for delta_x = " + str(tolerance) + " instead")
-            delta_x = tolerance
+            return True
         x_binned = bin_to_precision(x, delta_x)
 
         # This test checks if the bins are equal or larger than delta_x.

--- a/seismostats/utils/binning.py
+++ b/seismostats/utils/binning.py
@@ -104,6 +104,10 @@ def binning_test(
             otherwise.
 
     """
+    if len(x) == 0:
+        # error if the array is empty
+        raise ValueError("The given array has no entry")
+
     if delta_x == 0:
         range = np.max(x) - np.min(x)
         power = np.arange(np.floor(np.log10(tolerance)) + 1,


### PR DESCRIPTION
I worked on two issues here:

1. The a/b-value estimators gave an incorrect error
-> when there was no magnitudes above mc, it gave back a binning error, this is fixed now.
-> While I was on it, I also included an error if there were nan values
-> Also, I changed the order: first sanity check, then filtering

2. I included the possibility of including a time vector for the b-positive methods
-> Now, the magnitudes do not have to be given sorted if the time is given
-> While on it, I included the capability of including the index as an attribute of the class. Now, it is very easy to retrieve the actual magnitudes used: `magnitudes[estimator.idx]`. This is super useful also, when there is some other array that we want to filter in the same way as the magnitude differences are.

@lmizrahi : Would be cool if you used the estimator and checked if it works correctly 
@schmidni : I messed a bit with the estimator classes, so I thought it would be good to have you loook at it :)