### PR TITLE
made sure that different bin center does not change biningtest result

### DIFF
--- a/seismostats/utils/binning.py
+++ b/seismostats/utils/binning.py
@@ -147,6 +147,10 @@ def binning_test(
     # filter out NaN values
     x = x[~np.isnan(x)]
 
+    # shift the array to the smallest value (to avoid that the bin-center has
+    # an effect on the test)
+    x = x - np.min(x)
+
     if delta_x == 0 and check_larger_binning is True:
         range = np.max(x) - np.min(x)
         power = np.arange(


### PR DESCRIPTION
The binning test did assume that the center of the bin was at zero (or a multiple of delta_m away from it).
However, this is not necessary. It might be that the binning is centered at 0.01 while delta_m = 0.1. Then, the bins would be as follows: 0.01, 0.11, 0.21, ..
The binning test should not give a mistake in this case. The current branch implemented exactly this.