### PR TITLE
docs: changing delta_m to fmd_bin in the user guide

### DIFF
--- a/docs/source/user/10minute_intro.md
+++ b/docs/source/user/10minute_intro.md
@@ -175,7 +175,7 @@ These methods help assess the quality of your catalog by identifying the lowest 
 > Calling any of the methods below will overwrite the `Catalog.mc` property with the newly estimated magnitude of completeness.
 
 ```python
->>> cat.estimate_mc_maxc(delta_m=0.1)
+>>> cat.estimate_mc_maxc(fmd_bin=0.1)
 >>> print(cat.mc)
 1.0
 >>> cat.estimate_mc_b_stability()

--- a/docs/source/user/estimate_mc.md
+++ b/docs/source/user/estimate_mc.md
@@ -31,7 +31,7 @@ This method is based on the work of Wiemer & Wyss 2000 and Woessner & Wiemer 200
                     1.1, 1.2, 2.0, 1.1, 1.2, 1.1, 1.2, 1.6,
                     1.9, 1.3, 1.7, 1.3, 1.0, 1.2, 1.7, 1.3,
                     1.3, 1.1, 1.5, 1.4]})
->>> cat.estimate_mc_maxc(delta_m=0.1)
+>>> cat.estimate_mc_maxc(fmd_bin=0.1)
 >>> cat.mc
 1.4
 ```

--- a/docs/source/user/plots.md
+++ b/docs/source/user/plots.md
@@ -13,13 +13,13 @@ FMD is a histogram-style plot that shows the number of earthquakes per magnitude
 
 ```python
 >>> from seismostats.plots import plot_fmd
->>> plot_fmd(magnitudes, delta_m=0.1)
+>>> plot_fmd(magnitudes, fmd_bin=0.1)
 
 # Also works as a catalog class method:
->>> cat.plot_fmd(delta_m=0.1)
+>>> cat.plot_fmd(fmd_bin=0.1)
 ```
 
-Key arguments are the list of magnitudes and width of magnitude bins. The width of the magnitude bins best for visualisation purposes is not necessarily the one corresponding to the catalog binning. If used as a catalog method, the function will assume the catalog binning as the default `delta_m`, but you may still want to specify a different one! Optional arguments include plotting options such as `bin_position`, `color`, `size`, `legend`.
+Key arguments are the list of magnitudes and width of magnitude bins. The width of the magnitude bins best for visualisation purposes is not necessarily the one corresponding to the catalog binning. If used as a catalog method, the function will not assume the catalog binning `delta_m` as the default `fmd_bin`. Optional arguments include plotting options such as `bin_position`, `color`, `size`, `legend`.
 
 ### 1.2 Cumulative frequency-magnitude distribution
 The cumulative FMD shows the total number of events with magnitudes equal to or greater than a given value. This representation is log-linear and fits naturally with the Gutenberg-Richter law.
@@ -78,7 +78,7 @@ Function {func}`plot_mags_in_time <seismostats.plots.plot_mags_in_time>` visuali
 
 ```python
 >>> from seismostats.plots import plot_mags_in_time
->>> plot_mags_in_time(times,magnitudes)
+>>> plot_mags_in_time(times, magnitudes)
 ```
 
 Also works as a catalog class method:


### PR DESCRIPTION
Docstrings were fine in the last branch, but user guide has not been updated. The notebooks still need updating, but there's also other work to be done there.