### PR TITLE
include value property for both a and b-value estimator, and std for a,

### DIFF
--- a/seismostats/analysis/avalue/base.py
+++ b/seismostats/analysis/avalue/base.py
@@ -151,6 +151,24 @@ class AValueEstimator(ABC):
         return self.__a_value
 
     @property
+    def value(self) -> float:
+        '''
+        The a value of the Gutenberg-Richter law.
+        '''
+        if self.__a_value is None:
+            raise AttributeError('Please calculate the a-value first.')
+        return self.__a_value
+
+    @property
+    def std(self):
+        '''
+        Uncertainty of the a-value estimate, implemented as a placeholder.
+        This method can be overridden in subclasses to provide a specific
+        uncertainty estimation.
+        '''
+        return None
+
+    @property
     def magnitudes(self) -> np.ndarray:
         '''
         The magnitudes used to estimate the a-value.

--- a/seismostats/analysis/avalue/tests/test_base.py
+++ b/seismostats/analysis/avalue/tests/test_base.py
@@ -54,3 +54,10 @@ def test_reference_scaling():
         estimator.calculate(mags, mc=0, delta_m=0.1, m_ref=0)
 
     # TODO: test that the scaling is correct
+
+
+def test_value():
+    mags = np.array([0.1, 0.3, -0., 0.5, 0.4, 0.1, 0.3, -0., 0.2, 1.])
+    estimator = ClassicAValueEstimator()
+    estimator.calculate(mags, mc=0, delta_m=0.1)
+    np.testing.assert_almost_equal(estimator.value, estimator.a_value)

--- a/seismostats/analysis/bvalue/base.py
+++ b/seismostats/analysis/bvalue/base.py
@@ -137,6 +137,15 @@ class BValueEstimator(ABC):
         return self.__b_value
 
     @property
+    def value(self) -> float:
+        '''
+        The b-value of the Gutenberg-Richter law.
+        '''
+        if self.__b_value is None:
+            raise AttributeError('Please calculate the a-value first.')
+        return self.__b_value
+
+    @property
     def beta(self) -> float:
         '''
         The beta value of the Gutenberg-Richter law.

--- a/seismostats/analysis/bvalue/tests/test_base.py
+++ b/seismostats/analysis/bvalue/tests/test_base.py
@@ -58,6 +58,13 @@ def test_beta():
     np.testing.assert_almost_equal(estimator.beta, 2.9626581614317242)
 
 
+def test_value():
+    mags = np.array([0.1, 0.3, -0., 0.5, 0.4, 0.1, 0.3, -0., 0.2, 1.])
+    estimator = ClassicBValueEstimator()
+    estimator.calculate(mags, mc=0, delta_m=0.1)
+    np.testing.assert_almost_equal(estimator.value, estimator.b_value)
+
+
 def test_getters():
     mags = simulate_magnitudes_binned(n=100, b=1, mc=0, delta_m=0.1)
     weights = np.ones_like(mags)


### PR DESCRIPTION
The goal with this is to make the classes more easily usable (the code could be written either for a-value or b-value estimators, without having to include which one it is)